### PR TITLE
Add Buttondown to list of email platforms

### DIFF
--- a/marketing-checklist.md
+++ b/marketing-checklist.md
@@ -100,6 +100,7 @@ permalink: /marketing-checklist/
   - [ ] [Mad Mimi](https://madmimi.com/)
   - [ ] [Constant Contact](https://www.constantcontact.com/home/signup.jsp)
   - [ ] [FreshMail](https://freshmail.com/)
+  - [ ] [Buttondown](https://buttondown.email)
 
 - [ ] Create a standard email template for your brand.
 - [ ] Create transactional emails for when users sign up/purchase.


### PR DESCRIPTION
Buttondown is a free email marketing platform for new companies and side projects!  Thought I'd throw it in as its API and markdown support makes it particularly founder-friendly :).